### PR TITLE
feat(navbar): complete theme toggle with persistence, transitions, and light-mode polish #6

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import Landing from "./pages/LandingPage"
 import NotFound from "./pages/NotFound"
 import { Footer } from "./components/footer"
 import { Navbar } from "./components/NavBar"
+import { ThemeProvider } from "./contexts/ThemeContext"
 
 // Wrapper component to conditionally render the navbar
 function AppContent() {
@@ -13,7 +14,7 @@ function AppContent() {
   const isLandingPage = location.pathname === "/"
 
   return (
-    <div className="flex min-h-screen flex-col bg-gradient-to-b from-[#0d1117] to-[#170a28]">
+    <div className="flex min-h-screen flex-col bg-gradient-to-b from-[var(--app-gradient-start)] to-[var(--app-gradient-end)]">
       {/* Only show navbar on non-landing pages */}
       {!isLandingPage && <Navbar />}
 
@@ -40,9 +41,11 @@ function AppContent() {
 
 function App() {
   return (
-    <Router>
-      <AppContent />
-    </Router>
+    <ThemeProvider>
+      <Router>
+        <AppContent />
+      </Router>
+    </ThemeProvider>
   )
 }
 

--- a/src/components/DynamicBG.tsx
+++ b/src/components/DynamicBG.tsx
@@ -1,21 +1,28 @@
 import Particles from "react-tsparticles";
 import { loadTrianglesPreset } from "tsparticles-preset-triangles";
 import { Engine } from "tsparticles-engine"; // Import the correct type
+import { useTheme } from "../contexts/ThemeContext";
 
 export default function TrianglesBackground() {
+    const { isDarkMode } = useTheme();
+    
     async function particlesInit(main: Engine) { // Explicitly type 'main'
         await loadTrianglesPreset(main);
     }
+
+    // Theme-aware particle colors
+    const particleColor = isDarkMode ? "#A259FF" : "#8B5CF6"; // Purple for dark, slightly different purple for light
+    const linkColor = isDarkMode ? "#A259FF" : "#8B5CF6";
 
     const options = {
         background: { color: "transparent" }, // transparent to show CSS gradient
         particles: {
           number: { value: 40 }, // Reduced from 60 to 40
-          color: { value: "#A259FF" },
+          color: { value: particleColor },
           shape: { type: "triangle" },
-          opacity: { value: 0.3 }, // Reduced opacity
+          opacity: { value: isDarkMode ? 0.3 : 0.2 }, // Slightly more transparent in light mode
           size: { value: 2 }, // Reduced size
-          links: { enable: true, color: "#A259FF", width: 1, opacity: 0.4 }, // Reduced link opacity
+          links: { enable: true, color: linkColor, width: 1, opacity: isDarkMode ? 0.4 : 0.3 }, // Reduced link opacity in light mode
           move: { enable: true, speed: 0.8 }, // Reduced speed from 1.2 to 0.8
         },
         fpsLimit: 30, // Limit FPS to 30 for better performance

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -5,6 +5,7 @@ import { motion, AnimatePresence } from "framer-motion"
 import { Moon, Sun, Menu, X } from "lucide-react"
 import { cn } from "../lib/utils"
 import { Link, useLocation } from "react-router-dom"
+import { useTheme } from "../contexts/ThemeContext"
 
 interface NavbarProps {
   className?: string
@@ -12,9 +13,9 @@ interface NavbarProps {
 
 export function Navbar({ className }: NavbarProps) {
   const [scrolled, setScrolled] = useState(false)
-  const [isDarkMode, setIsDarkMode] = useState(true)
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const location = useLocation()
+  const { isDarkMode, toggleTheme } = useTheme()
 
   // Handle scroll effect for condensing
   useEffect(() => {
@@ -28,28 +29,6 @@ export function Navbar({ className }: NavbarProps) {
     window.addEventListener("scroll", handleScroll)
     return () => window.removeEventListener("scroll", handleScroll)
   }, [scrolled])
-
-  // Initialize theme from localStorage or system preference
-  useEffect(() => {
-    const root = document.documentElement
-    const storedTheme = localStorage.getItem("theme") as "dark" | "light" | null
-    const prefersDark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches
-    const shouldUseDark = storedTheme ? storedTheme === "dark" : prefersDark
-    setIsDarkMode(shouldUseDark)
-    root.classList.toggle("dark", shouldUseDark)
-  }, [])
-
-  // Handle theme change side effects (DOM class + persistence + smooth transition)
-  useEffect(() => {
-    const root = document.documentElement
-    root.classList.add("theme-transition")
-    root.classList.toggle("dark", isDarkMode)
-    localStorage.setItem("theme", isDarkMode ? "dark" : "light")
-    const timeout = window.setTimeout(() => {
-      root.classList.remove("theme-transition")
-    }, 300)
-    return () => window.clearTimeout(timeout)
-  }, [isDarkMode])
 
   // Navigation items with their routes
   const navItems = [
@@ -76,7 +55,7 @@ export function Navbar({ className }: NavbarProps) {
       {/* Background - adapts to light/dark */}
       <div
         className={cn(
-          "absolute inset-0 transition-all duration-300 backdrop-blur-md",
+          "absolute inset-0 transition-all duration-75 backdrop-blur-md",
           isDarkMode
             ? (scrolled
                 ? "bg-gradient-to-r from-[#080a10]/95 via-[#0a0613]/95 to-[#080a10]/95"
@@ -105,7 +84,7 @@ export function Navbar({ className }: NavbarProps) {
             src="New.png"
             alt="Logo"
             className={cn(
-              "transition-all duration-300",
+              "transition-all duration-75",
               scrolled ? "h-7 w-auto" : "h-10 w-auto",
               "drop-shadow",
               !isDarkMode && "filter brightness-0",
@@ -141,7 +120,7 @@ export function Navbar({ className }: NavbarProps) {
           <Link to={item.path} key={item.name}>
             <motion.button
               className={cn(
-                "relative mx-1 rounded-full px-4 py-2 text-sm font-medium transition-colors",
+                "relative mx-1 rounded-full px-4 py-2 text-sm font-medium transition-colors duration-75",
                 scrolled ? "py-2" : "py-3", // Taller buttons initially
                 isDarkMode
                   ? (location.pathname === item.path
@@ -178,7 +157,7 @@ export function Navbar({ className }: NavbarProps) {
           target="_blank"
           rel="noopener noreferrer"
           className={cn(
-            "flex items-center justify-center rounded-full backdrop-blur-lg transition-colors",
+            "flex items-center justify-center rounded-full backdrop-blur-lg transition-colors duration-75",
             isDarkMode
               ? "bg-white/5 text-gray-300 hover:bg-white/10 hover:text-white"
               : "bg-black/5 text-gray-900 hover:bg-purple-100 hover:text-purple-800",
@@ -194,13 +173,13 @@ export function Navbar({ className }: NavbarProps) {
         {/* Theme Toggle */}
         <motion.button
           className={cn(
-            "flex items-center justify-center rounded-full backdrop-blur-lg transition-colors",
+            "flex items-center justify-center rounded-full backdrop-blur-lg transition-colors duration-75",
             isDarkMode
               ? "bg-white/5 text-gray-300 hover:bg-white/10 hover:text-white"
               : "bg-black/5 text-gray-900 hover:bg-purple-100 hover:text-purple-800",
             scrolled ? "h-10 w-10" : "h-12 w-12", // Larger button initially
           )}
-          onClick={() => setIsDarkMode(!isDarkMode)}
+          onClick={toggleTheme}
           whileHover={{ scale: 1.05 }}
           whileTap={{ scale: 0.95 }}
           aria-label="Toggle theme"

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -5,6 +5,7 @@ import { useState, useEffect } from "react"
 import { Github, ExternalLink, Users, Info, Heart } from "lucide-react"
 import { motion } from "framer-motion"
 import { cn } from "../lib/utils"
+import { useTheme } from "../contexts/ThemeContext"
 
 interface FooterProps extends React.HTMLAttributes<HTMLElement> {
   variant?: "solid" | "darker-gradient" | "subtle-pattern"
@@ -12,29 +13,46 @@ interface FooterProps extends React.HTMLAttributes<HTMLElement> {
 
 export function Footer({ className, variant = "darker-gradient", ...props }: FooterProps) {
   const [currentYear, setCurrentYear] = useState(new Date().getFullYear())
+  const { isDarkMode } = useTheme()
 
   useEffect(() => {
     setCurrentYear(new Date().getFullYear())
   }, [])
 
-  // Background classes based on variant
+  // Background classes based on variant and theme
   const getBgClass = () => {
-    switch (variant) {
-      case "solid":
-        return "bg-[#0f0a1e]" // Solid dark color that's slightly darker than the end of your site gradient
-      case "darker-gradient":
-        return "bg-gradient-to-b from-[#170a28] to-[#0a0517]" // Continues from where your site ends to even darker
-      case "subtle-pattern":
-        return "bg-[#120920]" // Base color with pattern added via the decorative elements
-      default:
-        return "bg-gradient-to-b from-[#170a28] to-[#0a0517]"
+    if (isDarkMode) {
+      switch (variant) {
+        case "solid":
+          return "bg-[#0f0a1e]" // Solid dark color that's slightly darker than the end of your site gradient
+        case "darker-gradient":
+          return "bg-gradient-to-b from-[#170a28] to-[#0a0517]" // Continues from where your site ends to even darker
+        case "subtle-pattern":
+          return "bg-[#120920]" // Base color with pattern added via the decorative elements
+        default:
+          return "bg-gradient-to-b from-[#170a28] to-[#0a0517]"
+      }
+    } else {
+      switch (variant) {
+        case "solid":
+          return "bg-[#f8f9fa]" // Light solid color
+        case "darker-gradient":
+          return "bg-gradient-to-b from-[#f5f7fb] to-[#e8ecf0]" // Light gradient
+        case "subtle-pattern":
+          return "bg-[#f0f2f5]" // Light base color
+        default:
+          return "bg-gradient-to-b from-[#f5f7fb] to-[#e8ecf0]"
+      }
     }
   }
 
   return (
     <footer
       className={cn(
-        "relative mt-auto w-full overflow-hidden border-t border-white/10 py-10 text-white",
+        "relative mt-auto w-full overflow-hidden border-t py-10",
+        isDarkMode 
+          ? "border-white/10 text-white" 
+          : "border-gray-200 text-gray-800",
         getBgClass(),
         className,
       )}
@@ -50,14 +68,24 @@ export function Footer({ className, variant = "darker-gradient", ...props }: Foo
             className="mb-4"
           >
             <a href="/" className="inline-block">
-              <img src="New.png" alt="Logo" className="h-24 w-90 transition-transform duration-300 hover:scale-110" />
+              <img 
+                src="New.png" 
+                alt="Logo" 
+                className={cn(
+                  "h-24 w-90 transition-transform duration-75 hover:scale-110",
+                  !isDarkMode && "filter brightness-0"
+                )} 
+              />
             </a>
           </motion.div>
           <motion.p
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             transition={{ duration: 0.5, delay: 0.2 }}
-            className="text-sm text-gray-400"
+            className={cn(
+              "text-sm",
+              isDarkMode ? "text-gray-400" : "text-gray-600"
+            )}
           >
             Made with <Heart className="inline h-4 w-4 text-pink-500" fill="#ec4899" /> @ UC Davis
           </motion.p>
@@ -89,7 +117,10 @@ export function Footer({ className, variant = "darker-gradient", ...props }: Foo
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           transition={{ duration: 0.5, delay: 0.4 }}
-          className="text-center text-xs text-gray-500"
+          className={cn(
+            "text-center text-xs",
+            isDarkMode ? "text-gray-500" : "text-gray-600"
+          )}
         >
           <p>© {currentYear} ExpoLab. All rights reserved.</p>
         </motion.div>
@@ -127,6 +158,7 @@ interface FooterLinkProps {
 
 function FooterLink({ href, icon, children, className }: FooterLinkProps) {
   const isExternal = href.startsWith("http")
+  const { isDarkMode } = useTheme()
 
   return (
     <a
@@ -134,14 +166,17 @@ function FooterLink({ href, icon, children, className }: FooterLinkProps) {
       target={isExternal ? "_blank" : undefined}
       rel={isExternal ? "noopener noreferrer" : undefined}
       className={cn(
-        "group flex items-center gap-2 rounded-full bg-white/5 px-4 py-2 text-sm font-medium text-gray-300 backdrop-blur-sm transition-all duration-300 hover:bg-white/10 hover:text-white hover:shadow-lg hover:shadow-purple-500/10",
+        "group flex items-center gap-2 rounded-full px-4 py-2 text-sm font-medium backdrop-blur-sm transition-all duration-75 hover:shadow-lg hover:shadow-purple-500/10",
+        isDarkMode 
+          ? "bg-white/5 text-gray-300 hover:bg-white/10 hover:text-white"
+          : "bg-gray-100 text-gray-700 hover:bg-purple-100 hover:text-purple-800",
         className,
       )}
     >
-      <span className="transition-transform duration-300 group-hover:-translate-y-0.5 group-hover:scale-110">
+      <span className="transition-transform duration-75 group-hover:-translate-y-0.5 group-hover:scale-110">
         {icon}
       </span>
-      <span className="transition-transform duration-300 group-hover:-translate-y-0.5">{children}</span>
+      <span className="transition-transform duration-75 group-hover:-translate-y-0.5">{children}</span>
     </a>
   )
 }

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,0 +1,56 @@
+import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react'
+
+interface ThemeContextType {
+  isDarkMode: boolean
+  toggleTheme: () => void
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined)
+
+interface ThemeProviderProps {
+  children: ReactNode
+}
+
+export function ThemeProvider({ children }: ThemeProviderProps) {
+  const [isDarkMode, setIsDarkMode] = useState(true)
+
+  // Initialize theme from localStorage or system preference
+  useEffect(() => {
+    const root = document.documentElement
+    const storedTheme = localStorage.getItem("theme") as "dark" | "light" | null
+    const prefersDark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches
+    const shouldUseDark = storedTheme ? storedTheme === "dark" : prefersDark
+    setIsDarkMode(shouldUseDark)
+    root.classList.toggle("dark", shouldUseDark)
+  }, [])
+
+  // Handle theme change side effects (DOM class + persistence + smooth transition)
+  useEffect(() => {
+    const root = document.documentElement
+    root.classList.add("theme-transition")
+    root.classList.toggle("dark", isDarkMode)
+    localStorage.setItem("theme", isDarkMode ? "dark" : "light")
+    const timeout = window.setTimeout(() => {
+      root.classList.remove("theme-transition")
+    }, 50) // Ultra fast transition - almost instant
+    return () => window.clearTimeout(timeout)
+  }, [isDarkMode])
+
+  const toggleTheme = () => {
+    setIsDarkMode(!isDarkMode)
+  }
+
+  return (
+    <ThemeContext.Provider value={{ isDarkMode, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext)
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider')
+  }
+  return context
+}

--- a/src/index.css
+++ b/src/index.css
@@ -40,7 +40,7 @@ html, body {
   padding: 0;
   width: 100%;
   min-height: 100%;
-  background: linear-gradient(180deg, #0d1117, #170a28);
+  background-color: hsl(var(--background));
 }
 
 
@@ -91,6 +91,8 @@ button:focus-visible {
 
 @layer base {
   :root {
+    --app-gradient-start: #ffffff;
+    --app-gradient-end: #f5f7fb;
     --background: 0 0% 100%;
     --foreground: 20 14.3% 4.1%;
     --card: 0 0% 100%;
@@ -118,6 +120,8 @@ button:focus-visible {
     --radius: 0.5rem;
   }
   .dark {
+    --app-gradient-start: #0d1117;
+    --app-gradient-end: #170a28;
     --background: 20 14.3% 4.1%;
     --foreground: 60 9.1% 97.8%;
     --card: 20 14.3% 4.1%;
@@ -151,5 +155,11 @@ button:focus-visible {
   }
   body {
     @apply bg-background text-foreground;
+    background-image: linear-gradient(180deg, var(--app-gradient-start), var(--app-gradient-end));
   }
+}
+
+/* Smooth theme transition */
+.theme-transition, .theme-transition * {
+  transition: background-color 300ms ease, color 300ms ease, border-color 300ms ease, fill 300ms ease, stroke 300ms ease, background-image 300ms ease;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -159,7 +159,7 @@ button:focus-visible {
   }
 }
 
-/* Smooth theme transition */
+/* Ultra smooth theme transition */
 .theme-transition, .theme-transition * {
-  transition: background-color 300ms ease, color 300ms ease, border-color 300ms ease, fill 300ms ease, stroke 300ms ease, background-image 300ms ease;
+  transition: background-color 50ms ease, color 50ms ease, border-color 50ms ease, fill 50ms ease, stroke 50ms ease, background-image 50ms ease;
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,8 +2,12 @@ import Lottie from "lottie-react";
 import animationData1 from "../assets/blockchainDB.json";
 import animationData2 from "../assets/resDBAI.json";
 import Carousel from "../components/ui/carousel";
+import { useTheme } from "../contexts/ThemeContext";
+import { cn } from "../lib/utils";
 
 const HomePage = () => {
+  const { isDarkMode } = useTheme();
+  
   return (
     <div className="min-h-screen">
       <div className="flex justify-center items-center h-full w-full">
@@ -25,11 +29,20 @@ const HomePage = () => {
         </div>
         {/* Right Side - Text */}
         <div className="flex-1 flex flex-col justify-center text-left ml-10">
-          <h1 className="text-6xl font-bold text-purple-300 mb-4">ResilientDB</h1>
-          <p className="text-xl text-gray-200 mb-2">
+          <h1 className={cn(
+            "text-6xl font-bold mb-4",
+            isDarkMode ? "text-purple-300" : "text-purple-600"
+          )}>ResilientDB</h1>
+          <p className={cn(
+            "text-xl mb-2",
+            isDarkMode ? "text-gray-200" : "text-gray-800"
+          )}>
             Global-Scale Sustainable Blockchain Fabric
           </p>
-          <p className="text-lg text-gray-400">
+          <p className={cn(
+            "text-lg",
+            isDarkMode ? "text-gray-400" : "text-gray-600"
+          )}>
             ResilientDB is a high-performance blockchain database designed for scalability, speed, and fault tolerance.
             It enables secure, decentralized applications with reliable data consistency.
           </p>
@@ -38,11 +51,20 @@ const HomePage = () => {
       <div className="w-full max-w-7xl flex flex-col md:flex-row items-center gap-12 mx-auto mt-15">
       {/* Left Side - Text */}
       <div className="flex-1 flex flex-col justify-center text-left ml-10">
-        <h1 className="text-6xl font-bold text-purple-300 mb-4">What is ResAI?</h1>
-        <p className="text-xl text-gray-200 mb-2">
+        <h1 className={cn(
+          "text-6xl font-bold mb-4",
+          isDarkMode ? "text-purple-300" : "text-purple-600"
+        )}>What is ResAI?</h1>
+        <p className={cn(
+          "text-xl mb-2",
+          isDarkMode ? "text-gray-200" : "text-gray-800"
+        )}>
           ResAI is your intelligent assistant for exploring ResilientDB and beyond.
         </p>
-        <p className="text-lg text-gray-400">
+        <p className={cn(
+          "text-lg",
+          isDarkMode ? "text-gray-400" : "text-gray-600"
+        )}>
         ResAI helps you interactively query documentation, understand consensus protocols, and connect research insights
         directly to the codebase — making complex systems more accessible and insightful.
         </p>

--- a/src/pages/ToolsPage.tsx
+++ b/src/pages/ToolsPage.tsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { X } from "lucide-react";
+import { useTheme } from "../contexts/ThemeContext";
+import { cn } from "../lib/utils";
 
 interface Tool {
   id: string;
@@ -111,9 +113,10 @@ const tools: Tool[] = [
 
 const ToolsPage = () => {
   const [selectedTool, setSelectedTool] = useState<Tool | null>(null);
+  const { isDarkMode } = useTheme();
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-[#0d1117] to-[#170a28] py-32 px-4">
+    <div className="min-h-screen bg-gradient-to-b from-[var(--app-gradient-start)] to-[var(--app-gradient-end)] py-32 px-4">
       <div className="max-w-7xl mx-auto">
         {/* Header */}
         <div className="text-center mb-16">
@@ -122,7 +125,10 @@ const ToolsPage = () => {
               Our Tools
             </span>
           </h1>
-          <p className="text-xl text-gray-300 max-w-3xl mx-auto">
+          <p className={cn(
+            "text-xl max-w-3xl mx-auto",
+            isDarkMode ? "text-gray-300" : "text-gray-700"
+          )}>
             Discover the complete suite of AI-powered tools designed to enhance your experience with ResilientDB and blockchain technology.
           </p>
         </div>
@@ -132,7 +138,12 @@ const ToolsPage = () => {
           {tools.map((tool) => (
             <motion.div
               key={tool.id}
-              className="bg-white/5 backdrop-blur-lg rounded-xl p-6 border border-white/10 cursor-pointer group hover:bg-white/10 transition-all duration-300 hover:scale-105 hover:shadow-2xl hover:shadow-purple-500/20"
+              className={cn(
+                "backdrop-blur-lg rounded-xl p-6 border cursor-pointer group transition-all duration-75 hover:scale-105 hover:shadow-2xl hover:shadow-purple-500/20",
+                isDarkMode 
+                  ? "bg-white/5 border-white/10 hover:bg-white/10" 
+                  : "bg-white/80 border-gray-200 hover:bg-white/90"
+              )}
               onClick={() => setSelectedTool(tool)}
               whileHover={{ y: -5 }}
             >
@@ -146,7 +157,10 @@ const ToolsPage = () => {
                       {tool.name}
                     </span>
                   </h3>
-                  <p className="text-gray-300 leading-relaxed">
+                  <p className={cn(
+                    "leading-relaxed",
+                    isDarkMode ? "text-gray-300" : "text-gray-700"
+                  )}>
                     {tool.shortDescription}
                   </p>
                 </div>
@@ -170,13 +184,23 @@ const ToolsPage = () => {
               initial={{ scale: 0.8, opacity: 0 }}
               animate={{ scale: 1, opacity: 1 }}
               exit={{ scale: 0.8, opacity: 0 }}
-              className="bg-[#0d1117] border border-white/20 rounded-2xl max-w-4xl w-full max-h-[90vh] overflow-y-auto relative"
+              className={cn(
+                "border rounded-2xl max-w-4xl w-full max-h-[90vh] overflow-y-auto relative",
+                isDarkMode 
+                  ? "bg-[#0d1117] border-white/20" 
+                  : "bg-white border-gray-200"
+              )}
               onClick={(e) => e.stopPropagation()}
             >
               {/* Close Button */}
               <button
                 onClick={() => setSelectedTool(null)}
-                className="absolute top-4 right-4 text-gray-400 hover:text-white transition-colors z-10"
+                className={cn(
+                  "absolute top-4 right-4 transition-colors z-10",
+                  isDarkMode 
+                    ? "text-gray-400 hover:text-white" 
+                    : "text-gray-600 hover:text-gray-900"
+                )}
               >
                 <X size={24} />
               </button>
@@ -193,7 +217,10 @@ const ToolsPage = () => {
                         {selectedTool.name}
                       </span>
                     </h2>
-                    <p className="text-xl text-gray-300 leading-relaxed">
+                    <p className={cn(
+                      "text-xl leading-relaxed",
+                      isDarkMode ? "text-gray-300" : "text-gray-700"
+                    )}>
                       {selectedTool.longDescription}
                     </p>
                   </div>
@@ -203,10 +230,16 @@ const ToolsPage = () => {
                   {/* Features - Only show for actual tools */}
                   {selectedTool.id !== "coming-soon" && (
                     <div className="text-center">
-                      <h3 className="text-2xl font-bold mb-4 text-white">Key Features</h3>
+                      <h3 className={cn(
+                        "text-2xl font-bold mb-4",
+                        isDarkMode ? "text-white" : "text-gray-900"
+                      )}>Key Features</h3>
                       <ul className="space-y-2 inline-block text-left">
                         {selectedTool.features.map((feature, index) => (
-                          <li key={index} className="flex items-center text-gray-300">
+                          <li key={index} className={cn(
+                            "flex items-center",
+                            isDarkMode ? "text-gray-300" : "text-gray-700"
+                          )}>
                             <span className="w-2 h-2 bg-purple-500 rounded-full mr-3"></span>
                             {feature}
                           </li>
@@ -218,10 +251,16 @@ const ToolsPage = () => {
                   {/* Use Cases - Only show for actual tools */}
                   {selectedTool.id !== "coming-soon" && (
                     <div className="text-center">
-                      <h3 className="text-2xl font-bold mb-4 text-white">Use Cases</h3>
+                      <h3 className={cn(
+                        "text-2xl font-bold mb-4",
+                        isDarkMode ? "text-white" : "text-gray-900"
+                      )}>Use Cases</h3>
                       <ul className="space-y-2 inline-block text-left">
                         {selectedTool.useCases.map((useCase, index) => (
-                          <li key={index} className="flex items-center text-gray-300">
+                          <li key={index} className={cn(
+                            "flex items-center",
+                            isDarkMode ? "text-gray-300" : "text-gray-700"
+                          )}>
                             <span className="w-2 h-2 bg-cyan-500 rounded-full mr-3"></span>
                             {useCase}
                           </li>
@@ -237,7 +276,7 @@ const ToolsPage = () => {
                     href={selectedTool.link}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className={`inline-block px-8 py-4 bg-gradient-to-r ${selectedTool.color} hover:scale-105 rounded-lg text-white font-semibold shadow-lg transition-all duration-300`}
+                    className={`inline-block px-8 py-4 bg-gradient-to-r ${selectedTool.color} hover:scale-105 rounded-lg text-white font-semibold shadow-lg transition-all duration-75`}
                   >
                     {selectedTool.id === "coming-soon" ? "⭐ Star on GitHub" : `Launch ${selectedTool.name}`}
                   </a>


### PR DESCRIPTION
# Description

- The theme toggle now syncs with `document.documentElement`dark`` class for the entire page (was previously only in the navbar).
- Persist user theme in `localStorage`
- Smooth transition animations for color and background changes
- Light mode styles aligned with site palette (readable nav links, subtle gradients)
- Mobile menu and buttons adjusted for contrast
- The logo renders black in light mode for clarity and colored in dark mode

# video


https://github.com/user-attachments/assets/b9fa15db-e6ea-461d-9286-1536dc64ccce




# Testing
1. Click the theme toggle (moon/sun); colors switch smoothly across the whole page
2. Refresh page → theme persists
3. Check desktop and mobile nav → text readable in both themes
4. Verify logo: colored in dark mode, black in light mode

# Issue
Closes #6
